### PR TITLE
bugfix: crash with return value of type int8 or date

### DIFF
--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -558,7 +558,7 @@ Handle<Value> ODBC::GetColumnValue( SQLHSTMT hStmt, Column column,
                 // If SQLGetData is called more than one time in a row for a column containing fixed-length data, 
                 // it returns SQL_NO_DATA for all calls after the first.
 
-                // break;
+                break;
             }
 
           }


### PR DESCRIPTION
If you call a stored procedure that returns a value of type Int8 or Date, the node module allocates memory until the application crashes. The proposed code change addresses the problem.