### PR TITLE
Build support for linux | arm

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -62,6 +62,35 @@
         }
         ], 
 
+        ############### Linux ARM #################
+        [ 'OS == "linux" and target_arch =="arm" ', 
+        {
+          'conditions' : 
+          [
+
+          ],
+
+
+          'libraries' : 
+          [
+                '-L$(CSDK_HOME)/lib/cli', 
+                '-lthcli'
+          ],    
+
+
+          'include_dirs': 
+          [
+                '$(CSDK_HOME)/incl/cli'
+          ],
+
+
+          'cflags' : 
+          [
+            "-g "
+          ],
+        }
+        ], 
+
         ############### Linux 64bit #################
         [ 'OS == "linux" and target_arch =="x64" ', 
         {


### PR DESCRIPTION
The ${CSDK_HOME}/incl/cli directory was not being added
to the include path and was causing the build to fail on
Raspbian Jessie on a Model 2 B Raspberry Pi.

A condition check for OS=linux and target_arch=arm needed
to be added in binding.gyp. The build works as expected now.

Solves:
#13 